### PR TITLE
Add an option to install docker from distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ansible role to configure docker
   * [docker_networks_extra](#docker_networks_extra)
   * [docker_networks_general](#docker_networks_general)
   * [docker_registries](#docker_registries)
+  * [docker_upstream_version](#docker_upstream_version)
 * [Dependencies](#dependencies)
 * [License](#license)
 * [Author](#author)
@@ -131,6 +132,16 @@ docker_registries:
     email: docker@example.com
     reauthorize: False
     state: present
+```
+
+### docker_upstream_version
+
+Install from upstream repository
+
+#### Default value
+
+```YAML
+docker_upstream_version: true
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@
 # @end
 docker_registries: []
 
+# @var docker_upstream_version:description: Install from upstream repository
+docker_upstream_version: True
+
 # @var docker_daemon_command:description: Inject a service override into systemd
 docker_daemon_override: False
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     - docker
 
 - name: Download repo key
+  when: docker_upstream_version
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
@@ -19,6 +20,7 @@
     - docker
 
 - name: Add apt repository
+  when: docker_upstream_version
   apt_repository:
     repo: "deb [arch={{ docker_arch }}] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     filename: docker
@@ -29,7 +31,7 @@
 
 - name: Install required packages
   loop:
-    - docker-ce
+    - "{{ 'docker-ce' if docker_upstream_version else 'docker.io' }}"
     - python3-docker
   package:
     name: "{{ item }}"


### PR DESCRIPTION
For scenarios like a Kubernetes installation it's suggested to use the
Docker version shipped with Ubuntu, that's why we got an option to
disable the installation from the upstream repo.